### PR TITLE
Fix player view

### DIFF
--- a/src/scripts/apps/PinCushion.js
+++ b/src/scripts/apps/PinCushion.js
@@ -135,7 +135,7 @@ export class PinCushion {
 
 	static get FLAGS() {
 		return {
-			USE_PIN_REVEALED: "usePinRevealed",
+			USE_PIN_REVEALED: "usePinIsRevealed",
 			PIN_IS_REVEALED: "pinIsRevealed",
 			PIN_GM_TEXT: "gmNote",
 			HAS_BACKGROUND: "hasBackground",
@@ -1588,9 +1588,9 @@ export class PinCushion {
 
 		// IF not GM and IF  = enabled then take flag path as note.document.texture.src
 		if (!game.user.isGM) {
-			if (this.document && this.document.getFlag(PinCushion.MODULE_NAME, PinCushion.FLAGS.PLAYER_ICON_STATE)) {
-				this.document.texture.src = stripQueryStringAndHashFromPath(
-					this.document.getFlag(PinCushion.MODULE_NAME, PinCushion.FLAGS.PLAYER_ICON_PATH)
+			if (this?.getFlag(PinCushion.MODULE_NAME, PinCushion.FLAGS.PLAYER_ICON_STATE)) {
+				this.texture.src = stripQueryStringAndHashFromPath(
+					this.getFlag(PinCushion.MODULE_NAME, PinCushion.FLAGS.PLAYER_ICON_PATH)
 				);
 			}
 		}


### PR DESCRIPTION
Regardless of settings, player's don't see revealed notes. I think there is still an issue with colour (haven't tested fully), but the basic functionality is fixed by this:
* The flag set byt the GM in config is `usePinIsRevealed`, but the flag read to determine whether to show it to a player is `usePinRevealed`. The fix is to change the flag read to match.
* The custom player icon is not used because `_onPrepareNoteData` is called with `this` set to the document, so `this.document` is undefined. The fix is to use `this` instead of `this.document`.